### PR TITLE
Implement PojoSet.size

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "name": "Run Jest Tests",
+      "request": "launch",
+      "args": [
+        "--runInBand",
+        "--config",
+        "jestconfig.json"
+      ],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true,
+      "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+    }
+  ]
+}

--- a/src/PojoSet.ts
+++ b/src/PojoSet.ts
@@ -43,6 +43,15 @@ function toArray<T extends PropertyKey>(set: PojoSet<T>): T[] {
 }
 
 /**
+ * Count the number of values contained in a PojoSet.
+ * @param set A PojoSet
+ * @returns the number of values in the PojoSet
+ */
+function size<T extends PropertyKey>(set: PojoSet<T>): number {
+  return toArray(set).length;
+}
+
+/**
  * Create a PojoSet from the values of a Typescript Enum.
  *
  * @param enumObj A typescript `enum` object
@@ -175,6 +184,7 @@ export const PojoSet = {
   remove,
   toggle,
   has,
+  size,
   from,
   toArray,
   fromEnum,

--- a/src/__tests__/PojoSet.test.ts
+++ b/src/__tests__/PojoSet.test.ts
@@ -196,6 +196,12 @@ describe('PojoSet', () => {
     leibnizTest<typeof ssss, PojoSet<'a' | 'b' | 'c'> | PojoSet<'a' | 'b' | 'c' | 'd'>>(identity);
   });
 
+  it('should return the number of values in the set', () => {
+    const set = PojoSet.from(['a', 'b', 'c']);
+    expect(PojoSet.size(set)).toEqual(3);
+    expect(PojoSet.size(PojoSet.remove(set, 'b'))).toEqual(2);
+  });
+
   it('should create an empty set', () => {
     const s = PojoSet.empty<'a' | 'b'>();
     leibnizTest<typeof s, PojoSet<'a' | 'b'>>(identity);


### PR DESCRIPTION
Adds a method to return the number of items in the PojoSet. 

Also adds a VSCode config to run Jest Tests in a separate commit.